### PR TITLE
Return boolean (didRun) on runOrSkip

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ timeoutMinutes | `int` | `10` | number of minutes before timing out waiting for 
 markAsUnstableOnContinue | `bool` | `true` | flag indicating whether to mark the build as `"UNSTABLE"` if Continue is chosen
 body | `Closure` | | The work to perform
 
+Return Type | Description
+------------ | -------------
+`void` | N/A
+
 Example:
 
 ```groovy
@@ -88,17 +92,31 @@ timeoutMinutes | `int` | `1` | number of minutes before timing out waiting for u
 markAsUnstableOnSkip | `bool` | `true` | flag indicating whether to mark the build as `"UNSTABLE"` if Skip is chosen
 body | `Closure` | | The work to perform
 
+Return Type | Description
+------------ | -------------
+`boolean` | `true` if the block was run, `false` otherwise (i.e. was skipped)
+
 Example:
 
 ```groovy
 @Library('jenkins-pipeline-library')_
 
 stage('Demo') {
+  environment {
+    didRun = false
+  }
 
-  runOrSkip(description: "'my awesome work'", timeoutMinutes: 1) {
+  didRun = runOrSkip(description: "'my awesome work'", timeoutMinutes: 1) {
       echo "doing awesome work"
       (...)
     }
+
+  script {
+    if (didRun) {
+      echo "do stuff only when awesome work is run"
+      (...)
+    }
+  }
 
 }
 ```

--- a/vars/runOrSkip.groovy
+++ b/vars/runOrSkip.groovy
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-def call(Map vars, Closure body) {
+boolean call(Map vars, Closure body) {
 
     vars = vars ?: [:]
 
@@ -30,6 +30,7 @@ def call(Map vars, Closure body) {
         if (cause.getUser().toString() == 'SYSTEM') {
             echo "⏱ Input timed out! Running ${description}..."
             body()
+            return true
         } else {
             echo "❌ Aborting input on ${description}."
             throw timeoutException
@@ -40,7 +41,7 @@ def call(Map vars, Closure body) {
         case 'Run':
             echo "⚙️ Running ${description}..."
             body()
-            break
+            return true
         case 'Skip':
             if (markAsUnstableOnSkip) {
                 echo "⏭ Skipping ${description}, marking build is as unstable."
@@ -48,6 +49,6 @@ def call(Map vars, Closure body) {
             } else {
                 echo "⏭ Skipping ${description}, assuming build is ok."
             }
-            break
+            return false // did not run
     }
 }


### PR DESCRIPTION
Since some pipeline logic (e.g. `post`) might be dependent on code that runs inside `runOrSkip`, it's useful to have a flag indicating whether the block was ran or not.

Updated README to contain return types and respective descriptions.